### PR TITLE
Close Cerebro after copying to clipboard

### DIFF
--- a/src/Preview.js
+++ b/src/Preview.js
@@ -5,8 +5,8 @@ const styles = {
   textAlign: 'center'
 }
 
-module.exports = ({emojis, copy}) => (
+module.exports = ({emojis, actions}) => (
   <div style={styles}>
-    {emojis.map(e => <Emoji emoji={e} key={e} onClick={() => copy(e)} />)}
+    {emojis.map(e => <Emoji emoji={e} key={e} onClick={() => {actions.copyToClipboard(e); actions.hideWindow()}} />)}
   </div>
 )

--- a/src/index.js
+++ b/src/index.js
@@ -43,7 +43,7 @@ const fn = ({term, display, actions}) => {
         getPreview: () => (
           <Preview
             emojis={emojis}
-            copy={actions.copyToClipboard}
+            actions={actions}
           />
         )
       });


### PR DESCRIPTION
Hi @KELiON,

First, thank you again for Cerebro and its awesome plugins 🎉!

I've been using a lot the emoj plugin, and noticed something that bothered me (a lot): it doesn't close after I click the desired emoji!

This PR aims to implement the following behavior:

- User searches emoji
- She/He clicks on the desired emoji
- Cerebro hides and emoji is on her/his clipboard

If you agree to merge this PR, do you want me to append a new version so you can publish it to NPM?

Thanks!

> Also, there's no keyboard navigation, but that's for another PR. It's less bothering than Cerebro not closing after an emoji being selected.